### PR TITLE
UserModuleの実装

### DIFF
--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -3,6 +3,7 @@ import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ServersModule } from './servers/servers.module';
 import { RolesModule } from './roles/roles.module';
+import { UsersModule } from './users/users.module';
 
 @Module({
   imports: [
@@ -22,6 +23,7 @@ import { RolesModule } from './roles/roles.module';
     }),
     ServersModule,
     RolesModule,
+    UsersModule,
   ],
   controllers: [],
   providers: [],

--- a/api/src/roles/roles.controller.spec.ts
+++ b/api/src/roles/roles.controller.spec.ts
@@ -1,16 +1,34 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { RolesController } from './roles.controller';
+import { RolesService } from './roles.service';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Role } from './roles.entity';
+import { RoleRelation } from './role-relation.entity';
+import { UserRole } from '../users/entities/user-role.entity';
+import { User } from '../users/entities/user.entity';
 
 describe('RolesController', () => {
   let controller: RolesController;
+  let service: RolesService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
+      imports: [
+        TypeOrmModule.forRoot({
+          type: 'better-sqlite3',
+          database: ':memory:',
+          entities: [Role, RoleRelation, UserRole, User],
+          synchronize: true,
+        }),
+        TypeOrmModule.forFeature([Role, RoleRelation, UserRole, User]),
+      ],
       controllers: [RolesController],
+      providers: [RolesService],
     }).compile();
 
     controller = module.get<RolesController>(RolesController);
-  });
+    service = module.get<RolesService>(RolesService);
+  }, 30000);
 
   it('should be defined', () => {
     expect(controller).toBeDefined();

--- a/api/src/roles/roles.controller.ts
+++ b/api/src/roles/roles.controller.ts
@@ -32,10 +32,10 @@ export class RolesController {
     }
     @Get(':roleId/parents')
     async getParents(@Param('roleId') roleId: string) {
-        return await this.rolesService.getParents(roleId);
+        return await this.rolesService.getAllParents(roleId);
     }
     @Get(':roleId/children')
     async getChildren(@Param('roleId') roleId: string) {
-        return await this.rolesService.getChildren(roleId);
+        return await this.rolesService.getAllChildren(roleId);
     }
 }

--- a/api/src/roles/roles.entity.ts
+++ b/api/src/roles/roles.entity.ts
@@ -1,5 +1,6 @@
 import { Column, Entity, OneToMany, PrimaryColumn } from "typeorm";
 import { RoleRelation } from "./role-relation.entity";
+import { UserRole } from "../users/entities/user-role.entity";
 
 @Entity()
 export class Role {
@@ -14,4 +15,7 @@ export class Role {
 
     @OneToMany(() => RoleRelation, relation => relation.child)
     childRelations: RoleRelation[];
+
+    @OneToMany(() => UserRole, userRole => userRole.role)
+    userRoles: UserRole[];
 }

--- a/api/src/roles/roles.service.spec.ts
+++ b/api/src/roles/roles.service.spec.ts
@@ -1,18 +1,81 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { RolesService } from './roles.service';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Role } from './roles.entity';
+import { RoleRelation } from './role-relation.entity';
+import { UserRole } from '../users/entities/user-role.entity';
+import { User } from '../users/entities/user.entity';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
 
 describe('RolesService', () => {
   let service: RolesService;
+  let roleRepository: Repository<Role>;
+  let roleRelationRepository: Repository<RoleRelation>;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
+      imports: [
+        TypeOrmModule.forRoot({
+          type: 'better-sqlite3',
+          database: ':memory:',
+          entities: [Role, RoleRelation, UserRole, User],
+          synchronize: true,
+        }),
+        TypeOrmModule.forFeature([Role, RoleRelation, UserRole, User]),
+      ],
       providers: [RolesService],
     }).compile();
 
     service = module.get<RolesService>(RolesService);
-  });
+    roleRepository = module.get<Repository<Role>>(getRepositoryToken(Role));
+    roleRelationRepository = module.get<Repository<RoleRelation>>(getRepositoryToken(RoleRelation));
+  }, 30000);
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('create', () => {
+    it('should create a role', async () => {
+      const newRole = {
+        roleId: 'role123',
+        name: 'Test Role',
+      };
+
+      const result = await service.create(newRole.name, newRole.roleId);
+      expect(result).toEqual(expect.objectContaining(newRole));
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return an array of roles', async () => {
+      const role = {
+        roleId: 'role123',
+        name: 'Test Role',
+      };
+
+      await service.create(role.name, role.roleId);
+      const result = await service.findAll();
+      expect(result).toEqual(expect.arrayContaining([expect.objectContaining(role)]));
+    });
+  });
+
+  describe('findOne', () => {
+    it('should return a role', async () => {
+      const role = {
+        roleId: 'role123',
+        name: 'Test Role',
+      };
+
+      await service.create(role.name, role.roleId);
+      const result = await service.findOne(role.roleId);
+      expect(result).toEqual(expect.objectContaining(role));
+    });
+
+    it('should return null when role not found', async () => {
+      const result = await service.findOne('nonexistent');
+      expect(result).toBeNull();
+    });
   });
 });

--- a/api/src/roles/roles.service.ts
+++ b/api/src/roles/roles.service.ts
@@ -74,7 +74,12 @@ export class RolesService {
         });
     }
 
-    async getParents(roleId: string): Promise<Role[]> {
+    private async getAllParentsRecursive(roleId: string, visited: Set<string> = new Set()): Promise<Role[]> {
+        if (visited.has(roleId)) {
+            return []; // 循環参照を防ぐ
+        }
+        visited.add(roleId);
+
         const role = await this.roleRepository.findOne({
             where: { roleId },
             relations: ['childRelations', 'childRelations.parent']
@@ -84,10 +89,24 @@ export class RolesService {
             throw new Error('Role not found');
         }
 
-        return role.childRelations.map(relation => relation.parent);
+        const directParents = role.childRelations.map(relation => relation.parent);
+        const allParents = [...directParents];
+
+        // 各親ロールの親を再帰的に取得
+        for (const parent of directParents) {
+            const grandParents = await this.getAllParentsRecursive(parent.roleId, visited);
+            allParents.push(...grandParents);
+        }
+
+        return allParents;
     }
 
-    async getChildren(roleId: string): Promise<Role[]> {
+    private async getAllChildrenRecursive(roleId: string, visited: Set<string> = new Set()): Promise<Role[]> {
+        if (visited.has(roleId)) {
+            return []; // 循環参照を防ぐ
+        }
+        visited.add(roleId);
+
         const role = await this.roleRepository.findOne({
             where: { roleId },
             relations: ['parentRelations', 'parentRelations.child']
@@ -97,7 +116,24 @@ export class RolesService {
             throw new Error('Role not found');
         }
 
-        return role.parentRelations.map(relation => relation.child);
+        const directChildren = role.parentRelations.map(relation => relation.child);
+        const allChildren = [...directChildren];
+
+        // 各子ロールの子を再帰的に取得
+        for (const child of directChildren) {
+            const grandChildren = await this.getAllChildrenRecursive(child.roleId, visited);
+            allChildren.push(...grandChildren);
+        }
+
+        return allChildren;
+    }
+
+    async getAllParents(roleId: string): Promise<Role[]> {
+        return this.getAllParentsRecursive(roleId);
+    }
+
+    async getAllChildren(roleId: string): Promise<Role[]> {
+        return this.getAllChildrenRecursive(roleId);
     }
 
     async findAll(): Promise<Role[]> {

--- a/api/src/roles/roles.service.ts
+++ b/api/src/roles/roles.service.ts
@@ -99,4 +99,12 @@ export class RolesService {
 
         return role.parentRelations.map(relation => relation.child);
     }
+
+    async findAll(): Promise<Role[]> {
+        return this.roleRepository.find();
+    }
+
+    async findOne(roleId: string): Promise<Role | null> {
+        return this.roleRepository.findOne({ where: { roleId } });
+    }
 }

--- a/api/src/servers/servers.controller.spec.ts
+++ b/api/src/servers/servers.controller.spec.ts
@@ -1,18 +1,77 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ServersController } from './servers.controller';
+import { ServersService } from './servers.service';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Server } from './servers.entity';
 
 describe('ServersController', () => {
   let controller: ServersController;
+  let service: ServersService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
+      imports: [
+        TypeOrmModule.forRoot({
+          type: 'better-sqlite3',
+          database: ':memory:',
+          entities: [Server],
+          synchronize: true,
+        }),
+        TypeOrmModule.forFeature([Server]),
+      ],
       controllers: [ServersController],
+      providers: [ServersService],
     }).compile();
 
     controller = module.get<ServersController>(ServersController);
-  });
+    service = module.get<ServersService>(ServersService);
+  }, 30000);
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  describe('createServer', () => {
+    it('should create a server', async () => {
+      const newServer = {
+        serverId: '123456789',
+        name: 'Test Server',
+      };
+
+      jest.spyOn(service, 'create').mockResolvedValue(newServer as Server);
+
+      const result = await controller.createServer(newServer);
+      expect(result).toEqual(newServer);
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return an array of servers', async () => {
+      const servers = [
+        {
+          serverId: '123456789',
+          name: 'Test Server',
+        },
+      ];
+
+      jest.spyOn(service, 'findAll').mockResolvedValue(servers as Server[]);
+
+      const result = await controller.findAll();
+      expect(result).toEqual(servers);
+    });
+  });
+
+  describe('findOne', () => {
+    it('should return a server', async () => {
+      const server = {
+        serverId: '123456789',
+        name: 'Test Server',
+      };
+
+      jest.spyOn(service, 'findOne').mockResolvedValue(server as Server);
+
+      const result = await controller.findOne('123456789');
+      expect(result).toEqual(server);
+    });
   });
 });

--- a/api/src/servers/servers.controller.ts
+++ b/api/src/servers/servers.controller.ts
@@ -1,5 +1,6 @@
-import { Body, Controller, Delete, Param, Post } from '@nestjs/common';
+import { Body, Controller, Delete, Param, Post, Get } from '@nestjs/common';
 import { ServersService } from './servers.service';
+import { Server } from './servers.entity';
 
 @Controller('servers')
 export class ServersController {
@@ -15,5 +16,13 @@ export class ServersController {
     async deleteServer(@Param('serverId') serverId: string) {
         const server = await this.serversService.delete(serverId);
         return server;
+    }
+    @Get()
+    findAll() {
+        return this.serversService.findAll();
+    }
+    @Get(':serverId')
+    findOne(@Param('serverId') serverId: string) {
+        return this.serversService.findOne(serverId);
     }
 }

--- a/api/src/servers/servers.service.spec.ts
+++ b/api/src/servers/servers.service.spec.ts
@@ -1,18 +1,76 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ServersService } from './servers.service';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Server } from './servers.entity';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
 
 describe('ServersService', () => {
   let service: ServersService;
+  let serverRepository: Repository<Server>;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
+      imports: [
+        TypeOrmModule.forRoot({
+          type: 'better-sqlite3',
+          database: ':memory:',
+          entities: [Server],
+          synchronize: true,
+        }),
+        TypeOrmModule.forFeature([Server]),
+      ],
       providers: [ServersService],
     }).compile();
 
     service = module.get<ServersService>(ServersService);
-  });
+    serverRepository = module.get<Repository<Server>>(getRepositoryToken(Server));
+  }, 30000);
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('create', () => {
+    it('should create a server', async () => {
+      const newServer = {
+        serverId: '123456789',
+        name: 'Test Server',
+      };
+
+      const result = await service.create(newServer.name, newServer.serverId);
+      expect(result).toEqual(expect.objectContaining(newServer));
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return an array of servers', async () => {
+      const server = {
+        serverId: '123456789',
+        name: 'Test Server',
+      };
+
+      await service.create(server.name, server.serverId);
+      const result = await service.findAll();
+      expect(result).toEqual(expect.arrayContaining([expect.objectContaining(server)]));
+    });
+  });
+
+  describe('findOne', () => {
+    it('should return a server', async () => {
+      const server = {
+        serverId: '123456789',
+        name: 'Test Server',
+      };
+
+      await service.create(server.name, server.serverId);
+      const result = await service.findOne(server.serverId);
+      expect(result).toEqual(expect.objectContaining(server));
+    });
+
+    it('should return null when server not found', async () => {
+      const result = await service.findOne('nonexistent');
+      expect(result).toBeNull();
+    });
   });
 });

--- a/api/src/servers/servers.service.ts
+++ b/api/src/servers/servers.service.ts
@@ -13,6 +13,12 @@ export class ServersService {
         const server = this.serverRepository.create({ name, serverId });
         return this.serverRepository.save(server);
     }
+    async findAll(): Promise<Server[]> {
+        return this.serverRepository.find();
+    }
+    async findOne(serverId: string): Promise<Server | null> {
+        return this.serverRepository.findOne({ where: { serverId } });
+    }
     async delete(serverId: string): Promise<void> {
         await this.serverRepository.delete({ serverId });
     }

--- a/api/src/users/entities/user-role.entity.ts
+++ b/api/src/users/entities/user-role.entity.ts
@@ -1,0 +1,23 @@
+import { Entity, PrimaryColumn, Column, ManyToOne, JoinColumn } from 'typeorm';
+import { User } from './user.entity';
+import { Role } from '../../roles/roles.entity';
+
+@Entity()
+export class UserRole {
+  @PrimaryColumn()
+  discordId: string;
+
+  @PrimaryColumn()
+  roleId: string;
+
+  @Column({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP' })
+  assignedAt: Date;
+
+  @ManyToOne(() => User, user => user.userRoles)
+  @JoinColumn({ name: 'discordId' })
+  user: User;
+
+  @ManyToOne(() => Role)
+  @JoinColumn({ name: 'roleId' })
+  role: Role;
+} 

--- a/api/src/users/entities/user-role.entity.ts
+++ b/api/src/users/entities/user-role.entity.ts
@@ -13,7 +13,7 @@ export class UserRole {
   @Column()
   roleId: string;
 
-  @Column({ type: 'datetime' })
+  @Column({ type: 'timestamp' })
   assignedAt: Date;
 
   @ManyToOne(() => User, user => user.userRoles)

--- a/api/src/users/entities/user-role.entity.ts
+++ b/api/src/users/entities/user-role.entity.ts
@@ -13,7 +13,7 @@ export class UserRole {
   @Column()
   roleId: string;
 
-  @Column({ type: 'timestamp' })
+  @Column({ type: 'datetime' })
   assignedAt: Date;
 
   @ManyToOne(() => User, user => user.userRoles)

--- a/api/src/users/entities/user-role.entity.ts
+++ b/api/src/users/entities/user-role.entity.ts
@@ -1,23 +1,26 @@
-import { Entity, PrimaryColumn, Column, ManyToOne, JoinColumn } from 'typeorm';
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, JoinColumn } from 'typeorm';
 import { User } from './user.entity';
 import { Role } from '../../roles/roles.entity';
 
 @Entity()
 export class UserRole {
-  @PrimaryColumn()
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
   discordId: string;
 
-  @PrimaryColumn()
+  @Column()
   roleId: string;
 
-  @Column({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP' })
+  @Column({ type: 'datetime' })
   assignedAt: Date;
 
   @ManyToOne(() => User, user => user.userRoles)
   @JoinColumn({ name: 'discordId' })
   user: User;
 
-  @ManyToOne(() => Role)
+  @ManyToOne(() => Role, role => role.userRoles)
   @JoinColumn({ name: 'roleId' })
   role: Role;
 } 

--- a/api/src/users/entities/user.entity.ts
+++ b/api/src/users/entities/user.entity.ts
@@ -6,7 +6,7 @@ export class User {
   @PrimaryColumn()
   discordId: string;
 
-  @Column()
+  @Column({ nullable: true })
   username: string;
 
   @OneToMany(() => UserRole, userRole => userRole.user)

--- a/api/src/users/entities/user.entity.ts
+++ b/api/src/users/entities/user.entity.ts
@@ -1,0 +1,14 @@
+import { Entity, PrimaryColumn, Column, OneToMany } from 'typeorm';
+import { UserRole } from './user-role.entity';
+
+@Entity()
+export class User {
+  @PrimaryColumn()
+  discordId: string;
+
+  @Column()
+  username: string;
+
+  @OneToMany(() => UserRole, userRole => userRole.user)
+  userRoles: UserRole[];
+} 

--- a/api/src/users/users.controller.spec.ts
+++ b/api/src/users/users.controller.spec.ts
@@ -1,0 +1,58 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { UsersController } from './users.controller';
+import { UsersService } from './users.service';
+import { UserRole } from './entities/user-role.entity';
+
+describe('UsersController', () => {
+  let controller: UsersController;
+  let service: UsersService;
+
+  const mockUserRole = {
+    discordId: '123456789',
+    roleId: 'role123',
+    assignedAt: new Date(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [UsersController],
+      providers: [
+        {
+          provide: UsersService,
+          useValue: {
+            addRoleToUser: jest.fn(),
+            removeRoleFromUser: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<UsersController>(UsersController);
+    service = module.get<UsersService>(UsersService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('addRoleToUser', () => {
+    it('should add role to user', async () => {
+      jest.spyOn(service, 'addRoleToUser').mockResolvedValue(mockUserRole as UserRole);
+
+      const result = await controller.addRoleToUser('123456789', 'role123');
+
+      expect(result).toEqual(mockUserRole);
+      expect(service.addRoleToUser).toHaveBeenCalledWith('123456789', 'role123');
+    });
+  });
+
+  describe('removeRoleFromUser', () => {
+    it('should remove role from user', async () => {
+      jest.spyOn(service, 'removeRoleFromUser').mockResolvedValue();
+
+      await controller.removeRoleFromUser('123456789', 'role123');
+
+      expect(service.removeRoleFromUser).toHaveBeenCalledWith('123456789', 'role123');
+    });
+  });
+}); 

--- a/api/src/users/users.controller.spec.ts
+++ b/api/src/users/users.controller.spec.ts
@@ -37,11 +37,11 @@ describe('UsersController', () => {
 
   describe('addRoleToUser', () => {
     it('should add role to user', async () => {
-      jest.spyOn(service, 'addRoleToUser').mockResolvedValue(mockUserRole as UserRole);
+      jest.spyOn(service, 'addRoleToUser').mockResolvedValue([mockUserRole as UserRole]);
 
       const result = await controller.addRoleToUser('123456789', 'role123');
 
-      expect(result).toEqual(mockUserRole);
+      expect(result).toEqual([mockUserRole]);
       expect(service.addRoleToUser).toHaveBeenCalledWith('123456789', 'role123');
     });
   });

--- a/api/src/users/users.controller.ts
+++ b/api/src/users/users.controller.ts
@@ -1,5 +1,6 @@
 import { Controller, Post, Delete, Param } from '@nestjs/common';
 import { UsersService } from './users.service';
+import { UserRole } from './entities/user-role.entity';
 
 @Controller('users')
 export class UsersController {
@@ -9,7 +10,7 @@ export class UsersController {
   async addRoleToUser(
     @Param('discordId') discordId: string,
     @Param('roleId') roleId: string,
-  ) {
+  ): Promise<UserRole[]> {
     return this.usersService.addRoleToUser(discordId, roleId);
   }
 
@@ -17,7 +18,7 @@ export class UsersController {
   async removeRoleFromUser(
     @Param('discordId') discordId: string,
     @Param('roleId') roleId: string,
-  ) {
+  ): Promise<void> {
     return this.usersService.removeRoleFromUser(discordId, roleId);
   }
 } 

--- a/api/src/users/users.controller.ts
+++ b/api/src/users/users.controller.ts
@@ -1,0 +1,23 @@
+import { Controller, Post, Delete, Param } from '@nestjs/common';
+import { UsersService } from './users.service';
+
+@Controller('users')
+export class UsersController {
+  constructor(private readonly usersService: UsersService) {}
+
+  @Post(':discordId/roles/:roleId')
+  async addRoleToUser(
+    @Param('discordId') discordId: string,
+    @Param('roleId') roleId: string,
+  ) {
+    return this.usersService.addRoleToUser(discordId, roleId);
+  }
+
+  @Delete(':discordId/roles/:roleId')
+  async removeRoleFromUser(
+    @Param('discordId') discordId: string,
+    @Param('roleId') roleId: string,
+  ) {
+    return this.usersService.removeRoleFromUser(discordId, roleId);
+  }
+} 

--- a/api/src/users/users.module.ts
+++ b/api/src/users/users.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { UsersController } from './users.controller';
+import { UsersService } from './users.service';
+import { User } from './entities/user.entity';
+import { Role } from '../roles/roles.entity';
+import { UserRole } from './entities/user-role.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([User, Role, UserRole])],
+  controllers: [UsersController],
+  providers: [UsersService],
+  exports: [UsersService],
+})
+export class UsersModule {} 

--- a/api/src/users/users.module.ts
+++ b/api/src/users/users.module.ts
@@ -1,9 +1,9 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { UsersController } from './users.controller';
 import { UsersService } from './users.service';
 import { User } from './entities/user.entity';
 import { Role } from '../roles/roles.entity';
+import { UsersController } from './users.controller';
 import { UserRole } from './entities/user-role.entity';
 
 @Module({

--- a/api/src/users/users.module.ts
+++ b/api/src/users/users.module.ts
@@ -5,11 +5,13 @@ import { User } from './entities/user.entity';
 import { Role } from '../roles/roles.entity';
 import { UsersController } from './users.controller';
 import { UserRole } from './entities/user-role.entity';
+import { RolesService } from '../roles/roles.service';
+import { RoleRelation } from '../roles/role-relation.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User, Role, UserRole])],
+  imports: [TypeOrmModule.forFeature([User, Role, UserRole, RoleRelation])],
   controllers: [UsersController],
-  providers: [UsersService],
+  providers: [UsersService, RolesService],
   exports: [UsersService],
 })
 export class UsersModule {} 

--- a/api/src/users/users.service.spec.ts
+++ b/api/src/users/users.service.spec.ts
@@ -5,6 +5,7 @@ import { UsersService } from './users.service';
 import { User } from './entities/user.entity';
 import { Role } from '../roles/roles.entity';
 import { UserRole } from './entities/user-role.entity';
+import { RolesService } from '../roles/roles.service';
 
 describe('UsersService', () => {
   let service: UsersService;
@@ -36,6 +37,7 @@ describe('UsersService', () => {
           provide: getRepositoryToken(User),
           useValue: {
             findOne: jest.fn(),
+            save: jest.fn(),
           },
         },
         {
@@ -50,6 +52,14 @@ describe('UsersService', () => {
             findOne: jest.fn(),
             save: jest.fn(),
             remove: jest.fn(),
+            find: jest.fn(),
+          },
+        },
+        {
+          provide: RolesService,
+          useValue: {
+            getAllParents: jest.fn().mockResolvedValue([]),
+            getAllChildren: jest.fn().mockResolvedValue([]),
           },
         },
       ],
@@ -73,7 +83,7 @@ describe('UsersService', () => {
 
       const result = await service.addRoleToUser('123456789', 'role123');
 
-      expect(result).toEqual(mockUserRole);
+      expect(result).toEqual([mockUserRole]);
       expect(userRepository.findOne).toHaveBeenCalledWith({ where: { discordId: '123456789' } });
       expect(roleRepository.findOne).toHaveBeenCalledWith({ where: { roleId: 'role123' } });
       expect(userRoleRepository.save).toHaveBeenCalled();

--- a/api/src/users/users.service.spec.ts
+++ b/api/src/users/users.service.spec.ts
@@ -1,0 +1,115 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { UsersService } from './users.service';
+import { User } from './entities/user.entity';
+import { Role } from '../roles/roles.entity';
+import { UserRole } from './entities/user-role.entity';
+
+describe('UsersService', () => {
+  let service: UsersService;
+  let userRepository: Repository<User>;
+  let roleRepository: Repository<Role>;
+  let userRoleRepository: Repository<UserRole>;
+
+  const mockUser = {
+    discordId: '123456789',
+    username: 'testuser',
+  };
+
+  const mockRole = {
+    roleId: 'role123',
+    name: 'Test Role',
+  };
+
+  const mockUserRole = {
+    discordId: '123456789',
+    roleId: 'role123',
+    assignedAt: new Date(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UsersService,
+        {
+          provide: getRepositoryToken(User),
+          useValue: {
+            findOne: jest.fn(),
+          },
+        },
+        {
+          provide: getRepositoryToken(Role),
+          useValue: {
+            findOne: jest.fn(),
+          },
+        },
+        {
+          provide: getRepositoryToken(UserRole),
+          useValue: {
+            findOne: jest.fn(),
+            save: jest.fn(),
+            remove: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<UsersService>(UsersService);
+    userRepository = module.get<Repository<User>>(getRepositoryToken(User));
+    roleRepository = module.get<Repository<Role>>(getRepositoryToken(Role));
+    userRoleRepository = module.get<Repository<UserRole>>(getRepositoryToken(UserRole));
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('addRoleToUser', () => {
+    it('should add role to user successfully', async () => {
+      jest.spyOn(userRepository, 'findOne').mockResolvedValue(mockUser as User);
+      jest.spyOn(roleRepository, 'findOne').mockResolvedValue(mockRole as Role);
+      jest.spyOn(userRoleRepository, 'save').mockResolvedValue(mockUserRole as UserRole);
+
+      const result = await service.addRoleToUser('123456789', 'role123');
+
+      expect(result).toEqual(mockUserRole);
+      expect(userRepository.findOne).toHaveBeenCalledWith({ where: { discordId: '123456789' } });
+      expect(roleRepository.findOne).toHaveBeenCalledWith({ where: { roleId: 'role123' } });
+      expect(userRoleRepository.save).toHaveBeenCalled();
+    });
+
+    it('should throw error when user not found', async () => {
+      jest.spyOn(userRepository, 'findOne').mockResolvedValue(null);
+
+      await expect(service.addRoleToUser('123456789', 'role123')).rejects.toThrow('User or Role not found');
+    });
+
+    it('should throw error when role not found', async () => {
+      jest.spyOn(userRepository, 'findOne').mockResolvedValue(mockUser as User);
+      jest.spyOn(roleRepository, 'findOne').mockResolvedValue(null);
+
+      await expect(service.addRoleToUser('123456789', 'role123')).rejects.toThrow('User or Role not found');
+    });
+  });
+
+  describe('removeRoleFromUser', () => {
+    it('should remove role from user successfully', async () => {
+      jest.spyOn(userRoleRepository, 'findOne').mockResolvedValue(mockUserRole as UserRole);
+      jest.spyOn(userRoleRepository, 'remove').mockResolvedValue(mockUserRole as UserRole);
+
+      await service.removeRoleFromUser('123456789', 'role123');
+
+      expect(userRoleRepository.findOne).toHaveBeenCalledWith({
+        where: { discordId: '123456789', roleId: 'role123' }
+      });
+      expect(userRoleRepository.remove).toHaveBeenCalled();
+    });
+
+    it('should throw error when user role not found', async () => {
+      jest.spyOn(userRoleRepository, 'findOne').mockResolvedValue(null);
+
+      await expect(service.removeRoleFromUser('123456789', 'role123')).rejects.toThrow('User role not found');
+    });
+  });
+}); 

--- a/api/src/users/users.service.ts
+++ b/api/src/users/users.service.ts
@@ -1,11 +1,10 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Repository, In } from 'typeorm';
 import { User } from './entities/user.entity';
 import { Role } from '../roles/roles.entity';
 import { UserRole } from './entities/user-role.entity';
 import { RolesService } from '../roles/roles.service';
-import { In } from 'typeorm';
 
 @Injectable()
 export class UsersService {
@@ -28,7 +27,7 @@ export class UsersService {
     }
 
     // 親ロールを取得
-    const parentRoles = await this.rolesService.getParents(roleId);
+    const parentRoles = await this.rolesService.getAllParents(roleId);
     
     // 親ロールと子ロールを追加
     const addedRoles: UserRole[] = [];
@@ -63,7 +62,7 @@ export class UsersService {
     }
 
     // 親ロールを取得
-    const parentRoles = await this.rolesService.getParents(roleId);
+    const parentRoles = await this.rolesService.getAllParents(roleId);
 
     // 子ロールを削除
     await this.userRoleRepository.remove(userRole);
@@ -71,7 +70,7 @@ export class UsersService {
     // 各親ロールについて、他の子ロールとの紐付けを確認
     for (const parentRole of parentRoles) {
       // このユーザーが持っている、この親ロールに紐づく子ロールを取得
-      const childRoles = await this.rolesService.getChildren(parentRole.roleId);
+      const childRoles = await this.rolesService.getAllChildren(parentRole.roleId);
       
       // このユーザーが持っている、この親ロールに紐づく子ロールの数を確認
       const userChildRoles = await this.userRoleRepository.find({

--- a/api/src/users/users.service.ts
+++ b/api/src/users/users.service.ts
@@ -1,0 +1,45 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { User } from './entities/user.entity';
+import { Role } from '../roles/roles.entity';
+import { UserRole } from './entities/user-role.entity';
+
+@Injectable()
+export class UsersService {
+  constructor(
+    @InjectRepository(User)
+    private usersRepository: Repository<User>,
+    @InjectRepository(Role)
+    private rolesRepository: Repository<Role>,
+    @InjectRepository(UserRole)
+    private userRoleRepository: Repository<UserRole>,
+  ) {}
+
+  async addRoleToUser(discordId: string, roleId: string): Promise<UserRole> {
+    const user = await this.usersRepository.findOne({ where: { discordId } });
+    const role = await this.rolesRepository.findOne({ where: { roleId } });
+
+    if (!user || !role) {
+      throw new Error('User or Role not found');
+    }
+
+    const userRole = new UserRole();
+    userRole.discordId = discordId;
+    userRole.roleId = roleId;
+
+    return this.userRoleRepository.save(userRole);
+  }
+
+  async removeRoleFromUser(discordId: string, roleId: string): Promise<void> {
+    const userRole = await this.userRoleRepository.findOne({
+      where: { discordId, roleId }
+    });
+
+    if (!userRole) {
+      throw new Error('User role not found');
+    }
+
+    await this.userRoleRepository.remove(userRole);
+  }
+} 

--- a/api/src/users/users.service.ts
+++ b/api/src/users/users.service.ts
@@ -18,7 +18,12 @@ export class UsersService {
     private rolesService: RolesService,
   ) {}
 
-  async addRoleToUser(discordId: string, roleId: string): Promise<UserRole[]> {
+  private async addRoleToUserInternal(discordId: string, roleId: string, addedRoles: Set<string> = new Set()): Promise<UserRole[]> {
+    if (addedRoles.has(roleId)) {
+      return []; // 既に追加済みのロールはスキップ
+    }
+    addedRoles.add(roleId);
+
     const user = await this.usersRepository.findOne({ where: { discordId } });
     const role = await this.rolesRepository.findOne({ where: { roleId } });
 
@@ -26,29 +31,34 @@ export class UsersService {
       throw new Error('User or Role not found');
     }
 
-    // 親ロールを取得
+    const result: UserRole[] = [];
+
+    // 親ロールを取得して再帰的に追加
     const parentRoles = await this.rolesService.getAllParents(roleId);
-    
-    // 親ロールと子ロールを追加
-    const addedRoles: UserRole[] = [];
-    
-    // まず親ロールを追加
     for (const parentRole of parentRoles) {
-      const userRole = new UserRole();
-      userRole.discordId = discordId;
-      userRole.roleId = parentRole.roleId;
-      userRole.assignedAt = new Date();
-      addedRoles.push(await this.userRoleRepository.save(userRole));
+      const parentResults = await this.addRoleToUserInternal(discordId, parentRole.roleId, addedRoles);
+      result.push(...parentResults);
     }
 
-    // 次に子ロールを追加
-    const childUserRole = new UserRole();
-    childUserRole.discordId = discordId;
-    childUserRole.roleId = roleId;
-    childUserRole.assignedAt = new Date();
-    addedRoles.push(await this.userRoleRepository.save(childUserRole));
+    // 子ロールを取得して再帰的に追加
+    const childRoles = await this.rolesService.getAllChildren(roleId);
+    for (const childRole of childRoles) {
+      const childResults = await this.addRoleToUserInternal(discordId, childRole.roleId, addedRoles);
+      result.push(...childResults);
+    }
 
-    return addedRoles;
+    // 現在のロールを追加
+    const userRole = new UserRole();
+    userRole.discordId = discordId;
+    userRole.roleId = roleId;
+    userRole.assignedAt = new Date();
+    result.push(await this.userRoleRepository.save(userRole));
+
+    return result;
+  }
+
+  async addRoleToUser(discordId: string, roleId: string): Promise<UserRole[]> {
+    return this.addRoleToUserInternal(discordId, roleId);
   }
 
   async removeRoleFromUser(discordId: string, roleId: string): Promise<void> {

--- a/api/src/users/users.service.ts
+++ b/api/src/users/users.service.ts
@@ -4,6 +4,8 @@ import { Repository } from 'typeorm';
 import { User } from './entities/user.entity';
 import { Role } from '../roles/roles.entity';
 import { UserRole } from './entities/user-role.entity';
+import { RolesService } from '../roles/roles.service';
+import { In } from 'typeorm';
 
 @Injectable()
 export class UsersService {
@@ -14,9 +16,10 @@ export class UsersService {
     private rolesRepository: Repository<Role>,
     @InjectRepository(UserRole)
     private userRoleRepository: Repository<UserRole>,
+    private rolesService: RolesService,
   ) {}
 
-  async addRoleToUser(discordId: string, roleId: string): Promise<UserRole> {
+  async addRoleToUser(discordId: string, roleId: string): Promise<UserRole[]> {
     const user = await this.usersRepository.findOne({ where: { discordId } });
     const role = await this.rolesRepository.findOne({ where: { roleId } });
 
@@ -24,14 +27,33 @@ export class UsersService {
       throw new Error('User or Role not found');
     }
 
-    const userRole = new UserRole();
-    userRole.discordId = discordId;
-    userRole.roleId = roleId;
+    // 親ロールを取得
+    const parentRoles = await this.rolesService.getParents(roleId);
+    
+    // 親ロールと子ロールを追加
+    const addedRoles: UserRole[] = [];
+    
+    // まず親ロールを追加
+    for (const parentRole of parentRoles) {
+      const userRole = new UserRole();
+      userRole.discordId = discordId;
+      userRole.roleId = parentRole.roleId;
+      userRole.assignedAt = new Date();
+      addedRoles.push(await this.userRoleRepository.save(userRole));
+    }
 
-    return this.userRoleRepository.save(userRole);
+    // 次に子ロールを追加
+    const childUserRole = new UserRole();
+    childUserRole.discordId = discordId;
+    childUserRole.roleId = roleId;
+    childUserRole.assignedAt = new Date();
+    addedRoles.push(await this.userRoleRepository.save(childUserRole));
+
+    return addedRoles;
   }
 
   async removeRoleFromUser(discordId: string, roleId: string): Promise<void> {
+    // 削除対象のロールを取得
     const userRole = await this.userRoleRepository.findOne({
       where: { discordId, roleId }
     });
@@ -40,6 +62,34 @@ export class UsersService {
       throw new Error('User role not found');
     }
 
+    // 親ロールを取得
+    const parentRoles = await this.rolesService.getParents(roleId);
+
+    // 子ロールを削除
     await this.userRoleRepository.remove(userRole);
+
+    // 各親ロールについて、他の子ロールとの紐付けを確認
+    for (const parentRole of parentRoles) {
+      // このユーザーが持っている、この親ロールに紐づく子ロールを取得
+      const childRoles = await this.rolesService.getChildren(parentRole.roleId);
+      
+      // このユーザーが持っている、この親ロールに紐づく子ロールの数を確認
+      const userChildRoles = await this.userRoleRepository.find({
+        where: {
+          discordId,
+          roleId: In(childRoles.map(role => role.roleId))
+        }
+      });
+
+      // この親ロールに紐づく子ロールが他にない場合、親ロールも削除
+      if (userChildRoles.length === 0) {
+        const parentUserRole = await this.userRoleRepository.findOne({
+          where: { discordId, roleId: parentRole.roleId }
+        });
+        if (parentUserRole) {
+          await this.userRoleRepository.remove(parentUserRole);
+        }
+      }
+    }
   }
 } 

--- a/api/src/users/users.service.ts
+++ b/api/src/users/users.service.ts
@@ -24,8 +24,15 @@ export class UsersService {
     }
     addedRoles.add(roleId);
 
-    const user = await this.usersRepository.findOne({ where: { discordId } });
+    let user = await this.usersRepository.findOne({ where: { discordId } });
     const role = await this.rolesRepository.findOne({ where: { roleId } });
+
+    // ユーザーが存在しない場合は作成
+    if (!user) {
+      user = new User();
+      user.discordId = discordId;
+      user = await this.usersRepository.save(user);
+    }
 
     if (!user || !role) {
       throw new Error('User or Role not found');
@@ -36,15 +43,16 @@ export class UsersService {
     // 親ロールを取得して再帰的に追加
     const parentRoles = await this.rolesService.getAllParents(roleId);
     for (const parentRole of parentRoles) {
-      const parentResults = await this.addRoleToUserInternal(discordId, parentRole.roleId, addedRoles);
-      result.push(...parentResults);
-    }
+      // 親ロールが既にユーザーに割り当てられているか確認
+      const existingParentRole = await this.userRoleRepository.findOne({
+        where: { discordId, roleId: parentRole.roleId }
+      });
 
-    // 子ロールを取得して再帰的に追加
-    const childRoles = await this.rolesService.getAllChildren(roleId);
-    for (const childRole of childRoles) {
-      const childResults = await this.addRoleToUserInternal(discordId, childRole.roleId, addedRoles);
-      result.push(...childResults);
+      // 親ロールが割り当てられていない場合のみ追加
+      if (!existingParentRole) {
+        const parentResults = await this.addRoleToUserInternal(discordId, parentRole.roleId, addedRoles);
+        result.push(...parentResults);
+      }
     }
 
     // 現在のロールを追加

--- a/api/test/servers.e2e-spec.ts
+++ b/api/test/servers.e2e-spec.ts
@@ -1,0 +1,88 @@
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { ServersModule } from '../src/servers/servers.module';
+import { createTestingApp, clearDatabase, testServer } from './test-utils';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Server } from '../src/servers/entities/server.entity';
+
+describe('ServersController (e2e)', () => {
+  let app: INestApplication;
+  let serverRepository: Repository<Server>;
+
+  beforeAll(async () => {
+    app = await createTestingApp();
+    const moduleRef = app.select(ServersModule);
+    serverRepository = moduleRef.get<Repository<Server>>(getRepositoryToken(Server));
+  });
+
+  beforeEach(async () => {
+    await clearDatabase(app);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  describe('/servers (POST)', () => {
+    it('should create a server', () => {
+      return request(app.getHttpServer())
+        .post('/servers')
+        .send(testServer)
+        .expect(201)
+        .expect((res) => {
+          expect(res.body).toHaveProperty('serverId', testServer.serverId);
+          expect(res.body).toHaveProperty('name', testServer.name);
+        });
+    });
+
+    it('should return 400 when serverId is missing', () => {
+      const invalidServer = {
+        name: 'Test Server',
+      };
+
+      return request(app.getHttpServer())
+        .post('/servers')
+        .send(invalidServer)
+        .expect(400);
+    });
+  });
+
+  describe('/servers (GET)', () => {
+    it('should return an array of servers', async () => {
+      // テストデータの作成
+      await serverRepository.save(testServer);
+
+      return request(app.getHttpServer())
+        .get('/servers')
+        .expect(200)
+        .expect((res) => {
+          expect(Array.isArray(res.body)).toBe(true);
+          expect(res.body.length).toBe(1);
+          expect(res.body[0]).toHaveProperty('serverId', testServer.serverId);
+          expect(res.body[0]).toHaveProperty('name', testServer.name);
+        });
+    });
+  });
+
+  describe('/servers/:serverId (GET)', () => {
+    it('should return a server', async () => {
+      // テストデータの作成
+      await serverRepository.save(testServer);
+
+      return request(app.getHttpServer())
+        .get(`/servers/${testServer.serverId}`)
+        .expect(200)
+        .expect((res) => {
+          expect(res.body).toHaveProperty('serverId', testServer.serverId);
+          expect(res.body).toHaveProperty('name', testServer.name);
+        });
+    });
+
+    it('should return 404 when server not found', () => {
+      return request(app.getHttpServer())
+        .get('/servers/nonexistent')
+        .expect(404);
+    });
+  });
+}); 

--- a/api/test/test-utils.ts
+++ b/api/test/test-utils.ts
@@ -1,0 +1,53 @@
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { User } from '../src/users/entities/user.entity';
+import { Role } from '../src/roles/roles.entity';
+import { UserRole } from '../src/users/entities/user-role.entity';
+import { Server } from '../src/servers/servers.entity';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+export async function createTestingApp(): Promise<INestApplication> {
+  const moduleFixture: TestingModule = await Test.createTestingModule({
+    imports: [
+      TypeOrmModule.forRoot({
+        type: 'better-sqlite3',
+        database: ':memory:',
+        entities: [User, Role, UserRole, Server],
+        synchronize: true,
+      }),
+    ],
+  }).compile();
+
+  const app = moduleFixture.createNestApplication();
+  await app.init();
+  return app;
+}
+
+export async function clearDatabase(app: INestApplication): Promise<void> {
+  const userRoleRepo = app.get<Repository<UserRole>>(getRepositoryToken(UserRole));
+  const userRepo = app.get<Repository<User>>(getRepositoryToken(User));
+  const roleRepo = app.get<Repository<Role>>(getRepositoryToken(Role));
+  const serverRepo = app.get<Repository<Server>>(getRepositoryToken(Server));
+
+  await userRoleRepo.clear();
+  await userRepo.clear();
+  await roleRepo.clear();
+  await serverRepo.clear();
+}
+
+export const testUser = {
+  discordId: '123456789',
+  username: 'testuser',
+};
+
+export const testRole = {
+  roleId: 'role123',
+  name: 'Test Role',
+};
+
+export const testServer = {
+  serverId: '123456789',
+  name: 'Test Server',
+}; 

--- a/api/test/users.e2e-spec.ts
+++ b/api/test/users.e2e-spec.ts
@@ -1,0 +1,78 @@
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { UsersModule } from '../src/users/users.module';
+import { RolesModule } from '../src/roles/roles.module';
+import { createTestingApp, clearDatabase, testUser, testRole } from './test-utils';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { User } from '../src/users/entities/user.entity';
+import { Role } from '../src/roles/roles.entity';
+
+describe('UsersController (e2e)', () => {
+  let app: INestApplication;
+  let userRepository: Repository<User>;
+  let roleRepository: Repository<Role>;
+
+  beforeAll(async () => {
+    app = await createTestingApp();
+    const moduleRef = app.select(UsersModule);
+    userRepository = moduleRef.get<Repository<User>>(getRepositoryToken(User));
+    roleRepository = moduleRef.get<Repository<Role>>(getRepositoryToken(Role));
+  });
+
+  beforeEach(async () => {
+    await clearDatabase(app);
+    // テストデータの作成
+    await userRepository.save(testUser);
+    await roleRepository.save(testRole);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  describe('/users/:discordId/roles/:roleId (POST)', () => {
+    it('should add role to user', () => {
+      return request(app.getHttpServer())
+        .post(`/users/${testUser.discordId}/roles/${testRole.roleId}`)
+        .expect(201)
+        .expect((res) => {
+          expect(res.body).toHaveProperty('discordId', testUser.discordId);
+          expect(res.body).toHaveProperty('roleId', testRole.roleId);
+          expect(res.body).toHaveProperty('assignedAt');
+        });
+    });
+
+    it('should return 404 when user not found', () => {
+      return request(app.getHttpServer())
+        .post('/users/nonexistent/roles/role123')
+        .expect(404);
+    });
+
+    it('should return 404 when role not found', () => {
+      return request(app.getHttpServer())
+        .post(`/users/${testUser.discordId}/roles/nonexistent`)
+        .expect(404);
+    });
+  });
+
+  describe('/users/:discordId/roles/:roleId (DELETE)', () => {
+    it('should remove role from user', async () => {
+      // まずロールを追加
+      await request(app.getHttpServer())
+        .post(`/users/${testUser.discordId}/roles/${testRole.roleId}`)
+        .expect(201);
+
+      // ロールを削除
+      return request(app.getHttpServer())
+        .delete(`/users/${testUser.discordId}/roles/${testRole.roleId}`)
+        .expect(200);
+    });
+
+    it('should return 404 when user role not found', () => {
+      return request(app.getHttpServer())
+        .delete(`/users/${testUser.discordId}/roles/nonexistent`)
+        .expect(404);
+    });
+  });
+}); 


### PR DESCRIPTION
## 概要
Userとロールを結びつける機能を実装しました。それに伴い一部RolesServiceにも変更を加えました。

## 実装内容
- UserEntityとユーザーとロールを結びつける中間テーブルを定義
- Userをロールに紐づける、紐づけを解除する操作を実装 
  - 再帰的に探索を行うことで、親ロールを登録したら、親ロールの親ロールも登録する。子ロールを削除したら、他に子ロールがない場合親ロールも削除する。という処理を実現しました。
  - ユーザーが登録されていない場合、自動で登録。
- ロール紐づけ以外に対するテストの実装